### PR TITLE
getNodes() now returns a new NodeIterator instance on each invocation

### DIFF
--- a/src/main/java/com/tacitknowledge/jcr/testing/impl/MockNodeFactory.java
+++ b/src/main/java/com/tacitknowledge/jcr/testing/impl/MockNodeFactory.java
@@ -1,6 +1,8 @@
 package com.tacitknowledge.jcr.testing.impl;
 
 import com.tacitknowledge.jcr.testing.NodeFactory;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import javax.jcr.*;
 import javax.jcr.nodetype.NodeType;
@@ -118,9 +120,16 @@ public class MockNodeFactory implements NodeFactory {
     }
 
     @Override
-    public void createIteratorFor(Node parent, List<Node> childNodes) throws RepositoryException {
-        NodeIteratorAdapter nodeIteratorAdapter = new NodeIteratorAdapter(childNodes.iterator());
-        when(parent.getNodes()).thenReturn(nodeIteratorAdapter);
+    public void createIteratorFor(Node parent, final List<Node> childNodes) throws RepositoryException {
+        when(parent.getNodes()).thenAnswer(new Answer<NodeIterator>()
+        {
+            @Override
+            public NodeIterator answer(InvocationOnMock invocationOnMock) throws Throwable
+            {
+                return new NodeIteratorAdapter(childNodes.iterator());
+            }
+        });
+
         when(parent.getSession()).thenReturn(session);
     }
 

--- a/src/test/java/com/tacitknowledge/jcr/mocking/JcrMockServiceTest.java
+++ b/src/test/java/com/tacitknowledge/jcr/mocking/JcrMockServiceTest.java
@@ -38,6 +38,7 @@ public class JcrMockServiceTest {
                     "        }" +
                     "    }" +
                     "}";
+
     public static final String JSON_NODE_DEFINITION_WITH_TWO_NODES =
                     "{" +
                     "    ac2d111: {" +
@@ -51,6 +52,21 @@ public class JcrMockServiceTest {
                     "        }" +
                     "    }" +
                     "} ";
+
+    public static final String JSON_NODE_DEFINITION_WITH_PRIMARY_TYPE =
+                    "{" +
+                    "    ac2d111: {" +
+                    "        trustEntity: 'type:String'," +
+                    "        view: 'type:String'," +
+                    "        binary: {" +
+                    "            jcr:primaryType: 'nt:file'" +
+                    "        }," +
+                    "        anotherNode: {" +
+                    "            attri: 'valueyes'" +
+                    "        }" +
+                    "    }" +
+                    "} ";
+
 
     @BeforeClass
     public static void setup() throws RepositoryException, IOException {
@@ -286,4 +302,44 @@ public class JcrMockServiceTest {
         assertEquals("Property Name doesn't match", "testProperty", testProperty.getName());
         assertEquals("Property Value doesn't match", "myvalue", testProperty.getString());
     }
+
+    @Test
+    public void shouldBeAbleToIterateOnNodesMultipleTimes() throws RepositoryException {
+        String jsonNodeStructure =
+                "{" +
+                "    products: {" +
+                "        productA: {" +
+                "            name: 'Air Jordan'," +
+                "            confidentiality: 'Bronze'," +
+                "            someNode: {}," +
+                "            digitalAssets: {" +
+                "                asset1: {" +
+                "                    mimeType: 'jpg'," +
+                "                    contentType: 'photography'," +
+                "                    binary: 'type:Binary, value:/files/air_jordan.jpg'" +
+                "                }" +
+                "            }" +
+                "        }" +
+                "    }" +
+                "}";
+
+        Node rootNode = mockService.fromString(jsonNodeStructure);
+        assertNotNull(rootNode);
+
+        Node productANode = rootNode.getNode("products/productA");
+
+        assertNotNull(productANode);
+
+        //Call to JcrTestingUtils.assertIteratorCount will traverse the iterator
+        NodeIterator productAIterator = productANode.getNodes();
+        JcrTestingUtils.assertIteratorCount(productAIterator, 2);
+
+        //Traversing the iterator again should result in no nodes found
+        JcrTestingUtils.assertIteratorCount(productAIterator, 0);
+
+        //Calling getNodes() should return a fresh iterator which we can use to traverse the node tree again.
+        JcrTestingUtils.assertIteratorCount(productANode.getNodes(), 2);
+
+    }
+
 }

--- a/src/test/java/com/tacitknowledge/jcr/testing/impl/MockNodeFactoryTest.java
+++ b/src/test/java/com/tacitknowledge/jcr/testing/impl/MockNodeFactoryTest.java
@@ -191,6 +191,16 @@ public class MockNodeFactoryTest {
     }
 
     @Test
+    public void shouldCreateNewIteratorOnEachCallToGetNodes() throws RepositoryException {
+        List<Node> childNodes = new ArrayList<Node>();
+        nodeFactory.createIteratorFor(parent, childNodes);
+        NodeIterator firstNodeIterator = parent.getNodes();
+        NodeIterator secondNodeIterator = parent.getNodes();
+        assertNotSame("Consecutive calls to getNode() should return different iterator object", firstNodeIterator, secondNodeIterator);
+    }
+
+
+    @Test
     public void shouldCreateBinaryValue() throws RepositoryException {
 
         nodeFactory.createValueFor(property, "/files/air_jordan.jpg", PropertyType.BINARY);


### PR DESCRIPTION
- This will make it possible for iterating multiple times a node hierarchy.
