### PR TITLE
Fix typo in Maven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Usage
         <groupId>com.tacitknowledge</groupId>
         <artifactId>jcr-mock</artifactId>
         <version>2.1.5</version>
-        <scope>test<scope>
+        <scope>test</scope>
     </dependency>
 ```
 


### PR DESCRIPTION
Copying and pasting the Maven dependency snippet didn't work due to missing closing tag